### PR TITLE
#62: Add usePrevious hook. Update dependencies.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.9.0
+* [#62: Add `usePrevious` hook.](https://github.com/haensl/hooks/issues/62)
+* Update dependencies.
+
 ## 1.8.0
 * Add `useIsMounted` hook.
 * Migrate development to React 17.

--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ const DebouncedButton = () => {
 * [`useIsMounted`](#useIsMounted): keep track of whether or not a component is mounted.
 * [`useIsScrolling`](#useIsScrolling): keep track of whether or not the user is scrolling.
 * [`useOnScroll`](#useOnScroll): subscribe to scroll events.
+* [`usePrevious`](#usePrevious): keep track of a variable's previous value.
 * [`useWindowScroll`](#useWindowScroll): keep track of the `window`'s scroll position.
 * [`useWindowSize`](#useWindowSize): keep track of the `window`'s size.
 
@@ -218,6 +219,38 @@ const WindowScrollTracker = () => {
 ```
 
 #### [→ Codepen example](https://codepen.io/haensl/pen/wvMoLJK)
+
+### usePrevious(value)<a name="usePrevious"></a>
+
+Keeps track of changes to a value, storing it's _previous_ state.
+
+##### Example
+
+```javascript
+import { useEffect, useState } from 'react';
+import { usePrevious, useWindowScroll } from '@haensl/react-hooks';
+
+const ScrollDirectionTracker = () => {
+  const scrollPosition = useWindowScroll();
+  const previousScrollPosition = usePrevious(scrollPosition);
+  const [scrollDirection, setScrollDirection] = useState('down');
+
+  useEffect(() => {
+    if (previousScrollPosition.y < scrollPosition.y) {
+      setScrollDirection('down');
+    } else if (previousScrollPosition.y > scrollPosition.y) {
+      setScrollDirection('up');
+    }
+  }, [scrollPosition, previousScrollPosition]);
+
+  return (
+    <div className="ScrollDirectionTracker">
+      <span>User is scrolling</span>
+      <span>{ scrollDirection }px</span>
+    </div>
+  );
+};
+```
 
 ### useWindowScroll([debounceMs = 25])<a name="useWindowScroll"></a>
 Returns an object _(`null` if there is no `window`)_ with properties `x` and `y` reflecting the the scroll position of the `window` or `document`. Scroll position updates are by default debounced by 25 milliseconds. This debounce interval can be customized via the optional `debounceMs` argument. Please check the [example below](#useWindowScrollExample) as well as the [Codepen example](https://codepen.io/haensl/pen/VweMJGm).

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@haensl/react-hooks",
-  "version": "1.8.0",
+  "version": "1.9.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@haensl/react-hooks",
-      "version": "1.8.0",
+      "version": "1.9.0",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.12.5",
@@ -72,20 +72,20 @@
       }
     },
     "node_modules/@babel/core": {
-      "version": "7.16.7",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.16.7.tgz",
-      "integrity": "sha512-aeLaqcqThRNZYmbMqtulsetOQZ/5gbR/dWruUCJcpas4Qoyy+QeagfDsPdMrqwsPRDNxJvBlRiZxxX7THO7qtA==",
+      "version": "7.16.10",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.16.10.tgz",
+      "integrity": "sha512-pbiIdZbCiMx/MM6toR+OfXarYix3uz0oVsnNtfdAGTcCTu3w/JGF8JhirevXLBJUu0WguSZI12qpKnx7EeMyLA==",
       "dev": true,
       "dependencies": {
         "@babel/code-frame": "^7.16.7",
-        "@babel/generator": "^7.16.7",
+        "@babel/generator": "^7.16.8",
         "@babel/helper-compilation-targets": "^7.16.7",
         "@babel/helper-module-transforms": "^7.16.7",
         "@babel/helpers": "^7.16.7",
-        "@babel/parser": "^7.16.7",
+        "@babel/parser": "^7.16.10",
         "@babel/template": "^7.16.7",
-        "@babel/traverse": "^7.16.7",
-        "@babel/types": "^7.16.7",
+        "@babel/traverse": "^7.16.10",
+        "@babel/types": "^7.16.8",
         "convert-source-map": "^1.7.0",
         "debug": "^4.1.0",
         "gensync": "^1.0.0-beta.2",
@@ -208,9 +208,9 @@
       }
     },
     "node_modules/@babel/helper-create-class-features-plugin": {
-      "version": "7.16.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.16.7.tgz",
-      "integrity": "sha512-kIFozAvVfK05DM4EVQYKK+zteWvY85BFdGBRQBytRyY3y+6PX0DkDOn/CZ3lEuczCfrCxEzwt0YtP/87YPTWSw==",
+      "version": "7.16.10",
+      "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.16.10.tgz",
+      "integrity": "sha512-wDeej0pu3WN/ffTxMNCPW5UCiOav8IcLRxSIyp/9+IF2xJUM9h/OYjg0IJLHaL6F8oU8kqMz9nc1vryXhMsgXg==",
       "dev": true,
       "dependencies": {
         "@babel/helper-annotate-as-pure": "^7.16.7",
@@ -503,9 +503,9 @@
       }
     },
     "node_modules/@babel/highlight": {
-      "version": "7.16.7",
-      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.16.7.tgz",
-      "integrity": "sha512-aKpPMfLvGO3Q97V0qhw/V2SWNWlwfJknuwAunU7wZLSfrM4xTBvg7E5opUVi1kJTBKihE38CPg4nBiqX83PWYw==",
+      "version": "7.16.10",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.16.10.tgz",
+      "integrity": "sha512-5FnTQLSLswEj6IkgVw5KusNUUFY9ZGqe/TRFnP/BKYHYgfh7tc+C7mwiy95/yNP7Dh9x580Vv8r7u7ZfTBFxdw==",
       "dev": true,
       "dependencies": {
         "@babel/helper-validator-identifier": "^7.16.7",
@@ -517,9 +517,9 @@
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.16.8",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.16.8.tgz",
-      "integrity": "sha512-i7jDUfrVBWc+7OKcBzEe5n7fbv3i2fWtxKzzCvOjnzSxMfWMigAhtfJ7qzZNGFNMsCCd67+uz553dYKWXPvCKw==",
+      "version": "7.16.10",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.16.10.tgz",
+      "integrity": "sha512-Sm/S9Or6nN8uiFsQU1yodyDW3MWXQhFeqzMPM+t8MJjM+pLsnFVxFZzkpXKvUXh+Gz9cbMoYYs484+Jw/NTEFQ==",
       "dev": true,
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -1567,9 +1567,9 @@
       }
     },
     "node_modules/@babel/plugin-transform-runtime": {
-      "version": "7.16.8",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.16.8.tgz",
-      "integrity": "sha512-6Kg2XHPFnIarNweZxmzbgYnnWsXxkx9WQUVk2sksBRL80lBC1RAQV3wQagWxdCHiYHqPN+oenwNIuttlYgIbQQ==",
+      "version": "7.16.10",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.16.10.tgz",
+      "integrity": "sha512-9nwTiqETv2G7xI4RvXHNfpGdr8pAA+Q/YtN3yLK7OoK7n9OibVm/xymJ838a9A6E/IciOLPj82lZk0fW6O4O7w==",
       "dev": true,
       "dependencies": {
         "@babel/helper-module-imports": "^7.16.7",
@@ -1711,9 +1711,9 @@
       }
     },
     "node_modules/@babel/preset-env": {
-      "version": "7.16.8",
-      "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.16.8.tgz",
-      "integrity": "sha512-9rNKgVCdwHb3z1IlbMyft6yIXIeP3xz6vWvGaLHrJThuEIqWfHb0DNBH9VuTgnDfdbUDhkmkvMZS/YMCtP7Elg==",
+      "version": "7.16.10",
+      "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.16.10.tgz",
+      "integrity": "sha512-iCac3fZn9oOcLqc1N2/copPiX7aoxzsvjeDdXoZobrlbQ6YGgS3bL9HyldOJ8V8AY5P7pFynCATrn7M4dMw0Yg==",
       "dev": true,
       "dependencies": {
         "@babel/compat-data": "^7.16.8",
@@ -1890,9 +1890,9 @@
       }
     },
     "node_modules/@babel/traverse": {
-      "version": "7.16.8",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.16.8.tgz",
-      "integrity": "sha512-xe+H7JlvKsDQwXRsBhSnq1/+9c+LlQcCK3Tn/l5sbx02HYns/cn7ibp9+RV1sIUqu7hKg91NWsgHurO9dowITQ==",
+      "version": "7.16.10",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.16.10.tgz",
+      "integrity": "sha512-yzuaYXoRJBGMlBhsMJoUW7G1UmSb/eXr/JHYM/MsOJgavJibLwASijW7oXBdw3NQ6T0bW7Ty5P/VarOs9cHmqw==",
       "dev": true,
       "dependencies": {
         "@babel/code-frame": "^7.16.7",
@@ -1901,7 +1901,7 @@
         "@babel/helper-function-name": "^7.16.7",
         "@babel/helper-hoist-variables": "^7.16.7",
         "@babel/helper-split-export-declaration": "^7.16.7",
-        "@babel/parser": "^7.16.8",
+        "@babel/parser": "^7.16.10",
         "@babel/types": "^7.16.8",
         "debug": "^4.1.0",
         "globals": "^11.1.0"
@@ -4615,9 +4615,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.4.48",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.48.tgz",
-      "integrity": "sha512-RT3SEmpv7XUA+tKXrZGudAWLDpa7f8qmhjcLaM6OD/ERxjQ/zAojT8/Vvo0BSzbArkElFZ1WyZ9FuwAYbkdBNA==",
+      "version": "1.4.49",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.49.tgz",
+      "integrity": "sha512-k/0t1TRfonHIp8TJKfjBu2cKj8MqYTiEpOhci+q7CVEE5xnCQnx1pTa+V8b/sdhe4S3PR4p4iceEQWhGrKQORQ==",
       "dev": true
     },
     "node_modules/emittery": {
@@ -10352,20 +10352,20 @@
       "dev": true
     },
     "@babel/core": {
-      "version": "7.16.7",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.16.7.tgz",
-      "integrity": "sha512-aeLaqcqThRNZYmbMqtulsetOQZ/5gbR/dWruUCJcpas4Qoyy+QeagfDsPdMrqwsPRDNxJvBlRiZxxX7THO7qtA==",
+      "version": "7.16.10",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.16.10.tgz",
+      "integrity": "sha512-pbiIdZbCiMx/MM6toR+OfXarYix3uz0oVsnNtfdAGTcCTu3w/JGF8JhirevXLBJUu0WguSZI12qpKnx7EeMyLA==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.16.7",
-        "@babel/generator": "^7.16.7",
+        "@babel/generator": "^7.16.8",
         "@babel/helper-compilation-targets": "^7.16.7",
         "@babel/helper-module-transforms": "^7.16.7",
         "@babel/helpers": "^7.16.7",
-        "@babel/parser": "^7.16.7",
+        "@babel/parser": "^7.16.10",
         "@babel/template": "^7.16.7",
-        "@babel/traverse": "^7.16.7",
-        "@babel/types": "^7.16.7",
+        "@babel/traverse": "^7.16.10",
+        "@babel/types": "^7.16.8",
         "convert-source-map": "^1.7.0",
         "debug": "^4.1.0",
         "gensync": "^1.0.0-beta.2",
@@ -10452,9 +10452,9 @@
       }
     },
     "@babel/helper-create-class-features-plugin": {
-      "version": "7.16.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.16.7.tgz",
-      "integrity": "sha512-kIFozAvVfK05DM4EVQYKK+zteWvY85BFdGBRQBytRyY3y+6PX0DkDOn/CZ3lEuczCfrCxEzwt0YtP/87YPTWSw==",
+      "version": "7.16.10",
+      "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.16.10.tgz",
+      "integrity": "sha512-wDeej0pu3WN/ffTxMNCPW5UCiOav8IcLRxSIyp/9+IF2xJUM9h/OYjg0IJLHaL6F8oU8kqMz9nc1vryXhMsgXg==",
       "dev": true,
       "requires": {
         "@babel/helper-annotate-as-pure": "^7.16.7",
@@ -10675,9 +10675,9 @@
       }
     },
     "@babel/highlight": {
-      "version": "7.16.7",
-      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.16.7.tgz",
-      "integrity": "sha512-aKpPMfLvGO3Q97V0qhw/V2SWNWlwfJknuwAunU7wZLSfrM4xTBvg7E5opUVi1kJTBKihE38CPg4nBiqX83PWYw==",
+      "version": "7.16.10",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.16.10.tgz",
+      "integrity": "sha512-5FnTQLSLswEj6IkgVw5KusNUUFY9ZGqe/TRFnP/BKYHYgfh7tc+C7mwiy95/yNP7Dh9x580Vv8r7u7ZfTBFxdw==",
       "dev": true,
       "requires": {
         "@babel/helper-validator-identifier": "^7.16.7",
@@ -10686,9 +10686,9 @@
       }
     },
     "@babel/parser": {
-      "version": "7.16.8",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.16.8.tgz",
-      "integrity": "sha512-i7jDUfrVBWc+7OKcBzEe5n7fbv3i2fWtxKzzCvOjnzSxMfWMigAhtfJ7qzZNGFNMsCCd67+uz553dYKWXPvCKw==",
+      "version": "7.16.10",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.16.10.tgz",
+      "integrity": "sha512-Sm/S9Or6nN8uiFsQU1yodyDW3MWXQhFeqzMPM+t8MJjM+pLsnFVxFZzkpXKvUXh+Gz9cbMoYYs484+Jw/NTEFQ==",
       "dev": true
     },
     "@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression": {
@@ -11361,9 +11361,9 @@
       }
     },
     "@babel/plugin-transform-runtime": {
-      "version": "7.16.8",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.16.8.tgz",
-      "integrity": "sha512-6Kg2XHPFnIarNweZxmzbgYnnWsXxkx9WQUVk2sksBRL80lBC1RAQV3wQagWxdCHiYHqPN+oenwNIuttlYgIbQQ==",
+      "version": "7.16.10",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.16.10.tgz",
+      "integrity": "sha512-9nwTiqETv2G7xI4RvXHNfpGdr8pAA+Q/YtN3yLK7OoK7n9OibVm/xymJ838a9A6E/IciOLPj82lZk0fW6O4O7w==",
       "dev": true,
       "requires": {
         "@babel/helper-module-imports": "^7.16.7",
@@ -11451,9 +11451,9 @@
       }
     },
     "@babel/preset-env": {
-      "version": "7.16.8",
-      "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.16.8.tgz",
-      "integrity": "sha512-9rNKgVCdwHb3z1IlbMyft6yIXIeP3xz6vWvGaLHrJThuEIqWfHb0DNBH9VuTgnDfdbUDhkmkvMZS/YMCtP7Elg==",
+      "version": "7.16.10",
+      "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.16.10.tgz",
+      "integrity": "sha512-iCac3fZn9oOcLqc1N2/copPiX7aoxzsvjeDdXoZobrlbQ6YGgS3bL9HyldOJ8V8AY5P7pFynCATrn7M4dMw0Yg==",
       "dev": true,
       "requires": {
         "@babel/compat-data": "^7.16.8",
@@ -11600,9 +11600,9 @@
       }
     },
     "@babel/traverse": {
-      "version": "7.16.8",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.16.8.tgz",
-      "integrity": "sha512-xe+H7JlvKsDQwXRsBhSnq1/+9c+LlQcCK3Tn/l5sbx02HYns/cn7ibp9+RV1sIUqu7hKg91NWsgHurO9dowITQ==",
+      "version": "7.16.10",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.16.10.tgz",
+      "integrity": "sha512-yzuaYXoRJBGMlBhsMJoUW7G1UmSb/eXr/JHYM/MsOJgavJibLwASijW7oXBdw3NQ6T0bW7Ty5P/VarOs9cHmqw==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.16.7",
@@ -11611,7 +11611,7 @@
         "@babel/helper-function-name": "^7.16.7",
         "@babel/helper-hoist-variables": "^7.16.7",
         "@babel/helper-split-export-declaration": "^7.16.7",
-        "@babel/parser": "^7.16.8",
+        "@babel/parser": "^7.16.10",
         "@babel/types": "^7.16.8",
         "debug": "^4.1.0",
         "globals": "^11.1.0"
@@ -13679,9 +13679,9 @@
       }
     },
     "electron-to-chromium": {
-      "version": "1.4.48",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.48.tgz",
-      "integrity": "sha512-RT3SEmpv7XUA+tKXrZGudAWLDpa7f8qmhjcLaM6OD/ERxjQ/zAojT8/Vvo0BSzbArkElFZ1WyZ9FuwAYbkdBNA==",
+      "version": "1.4.49",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.49.tgz",
+      "integrity": "sha512-k/0t1TRfonHIp8TJKfjBu2cKj8MqYTiEpOhci+q7CVEE5xnCQnx1pTa+V8b/sdhe4S3PR4p4iceEQWhGrKQORQ==",
       "dev": true
     },
     "emittery": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@haensl/react-hooks",
-  "version": "1.8.0",
+  "version": "1.9.0",
   "description": "Assorted React hooks.",
   "main": "dist/hooks.cjs.js",
   "module": "dist/hooks.esm.js",

--- a/src/index.js
+++ b/src/index.js
@@ -4,6 +4,7 @@ import _useDebounce from './useDebounce';
 import _useIsMounted from './useIsMounted';
 import _useIsScrolling from './useIsScrolling';
 import _useOnScroll from './useOnScroll';
+import _usePrevious from './usePrevious';
 import _useWindowScroll from './useWindowScroll';
 import _useWindowSize from './useWindowSize';
 
@@ -13,6 +14,7 @@ export const useDebounce = _useDebounce;
 export const useIsMounted = _useIsMounted;
 export const useIsScrolling = _useIsScrolling;
 export const useOnScroll = _useOnScroll;
+export const usePrevious = _usePrevious;
 export const useWindowScroll = _useWindowScroll;
 export const useWindowSize = _useWindowSize;
 
@@ -23,6 +25,7 @@ const exports = {
   useIsMounted,
   useIsScrolling,
   useOnScroll,
+  usePrevious,
   useWindowScroll,
   useWindowSize
 };

--- a/src/package-tests/cjs/cjs.test.js
+++ b/src/package-tests/cjs/cjs.test.js
@@ -1,7 +1,19 @@
 import React, { useRef } from 'react';
 import ReactDOM from 'react-dom';
 import ResizeObserver from 'resize-observer-polyfill';
-import { useDebounce, useBoundingClientRect, useAnimationFrame, useIsMounted, useIsScrolling, useOnScroll, useWindowScroll, useWindowSize } from '@haensl/react-hooks';
+/* eslint-disable object-curly-newline */
+import {
+  useDebounce,
+  useBoundingClientRect,
+  useAnimationFrame,
+  useIsMounted,
+  useIsScrolling,
+  useOnScroll,
+  usePrevious,
+  useWindowScroll,
+  useWindowSize
+} from '@haensl/react-hooks';
+/* eslint-enable object-curly-newline */
 
 describe('cjs module test', () => {
   let container;
@@ -66,6 +78,28 @@ describe('cjs module test', () => {
 
         return (
           <span>useOnScroll test</span>
+        );
+      };
+    });
+
+    it('renders without crashing', () => {
+      ReactDOM.render(
+        <TestComponent />,
+        container
+      );
+      ReactDOM.unmountComponentAtNode(container);
+    });
+  });
+
+  describe('usePrevious', () => {
+    let TestComponent;
+
+    beforeAll(() => {
+      TestComponent = () => {
+        const previous = usePrevious(5);
+
+        return (
+          <span>usePrevious test. { previous }</span>
         );
       };
     });

--- a/src/package-tests/esm/esm.test.js
+++ b/src/package-tests/esm/esm.test.js
@@ -1,7 +1,19 @@
 import React, { useRef } from 'react';
 import { render } from '@testing-library/react';
 import ResizeObserver from 'resize-observer-polyfill';
-import { useAnimationFrame, useBoundingClientRect, useDebounce, useIsMounted, useIsScrolling, useOnScroll, useWindowScroll, useWindowSize } from '@haensl/react-hooks';
+/* eslint-disable object-curly-newline */
+import {
+  useAnimationFrame,
+  useBoundingClientRect,
+  useDebounce,
+  useIsMounted,
+  useIsScrolling,
+  useOnScroll,
+  usePrevious,
+  useWindowScroll,
+  useWindowSize
+} from '@haensl/react-hooks';
+/* eslint-enable object-curly-newline */
 
 describe('esm module test', () => {
   describe('useDebounce', () => {
@@ -56,6 +68,26 @@ describe('esm module test', () => {
 
         return (
           <span>useOnScroll test</span>
+        );
+      };
+    });
+
+    it('renders without crashing', () => {
+      expect(render.bind(render, <TestComponent />))
+        .not
+        .toThrow();
+    });
+  });
+
+  describe('usePrevious', () => {
+    let TestComponent;
+
+    beforeAll(() => {
+      TestComponent = () => {
+        const previous = usePrevious(5);
+
+        return (
+          <span>usePrevious test { previous }</span>
         );
       };
     });

--- a/src/usePrevious/index.js
+++ b/src/usePrevious/index.js
@@ -1,0 +1,13 @@
+import { useEffect, useRef } from 'react';
+
+const usePrevious = (value) => {
+  const ref = useRef();
+
+  useEffect(() => {
+    ref.current = value;
+  });
+
+  return ref.current;
+};
+
+export default usePrevious;

--- a/src/usePrevious/usePrevious.hook.test.js
+++ b/src/usePrevious/usePrevious.hook.test.js
@@ -1,0 +1,39 @@
+import { useState } from 'react';
+import { act, renderHook } from '@testing-library/react-hooks';
+import '@testing-library/jest-dom';
+import usePrevious from './';
+
+describe('usePrevious', () => {
+  test('renders without crashing', () => {
+    const val = 'foo';
+    const { result } = renderHook(() => usePrevious(val));
+    expect(result.error)
+      .not
+      .toBeDefined();
+  });
+
+  describe('when the value changes', () => {
+    test('returns the previous value', () => {
+      let val, setVal;
+
+      const { result } = renderHook(() => {
+        [val, setVal] = useState(5);
+        return usePrevious(val);
+      });
+
+      act(() => {
+        setVal(10);
+      });
+
+      expect(result.current)
+        .toEqual(5);
+
+      act(() => {
+        setVal(11);
+      });
+
+      expect(result.current)
+        .toEqual(10);
+    });
+  });
+});


### PR DESCRIPTION
## 1.9.0
* [#62: Add `usePrevious` hook.](https://github.com/haensl/hooks/issues/62)
* Update dependencies.

Closes #62