### PR TITLE
#71: Fix package badges.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 1.10.1
+* [#71: Fix package badges.](https://github.com/haensl/hooks/issues/71)
+
 ## 1.10.0
 * [#69: Add `useIsomorphicLayoutEffect` hook.](https://github.com/haensl/hooks/issues/69)
 * Update dependencies.

--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 Assorted React hooks.
 
-[![NPM](https://nodei.co/npm/@haensl%2Fhooks.png?downloads=true)](https://nodei.co/npm/@haensl%2Freact-hooks/)
+[![NPM](https://nodei.co/npm/@haensl%2Freact-hooks.png?downloads=true)](https://nodei.co/npm/@haensl%2Freact-hooks/)
 
-[![npm version](https://badge.fury.io/js/@haensl%2Fhooks.svg)](http://badge.fury.io/js/@haensl%2Freact-hooks)
+[![npm version](https://badge.fury.io/js/@haensl%2Freact-hooks.svg)](http://badge.fury.io/js/@haensl%2Freact-hooks)
 [![CircleCI](https://circleci.com/gh/haensl/hooks.svg?style=svg)](https://circleci.com/gh/haensl/hooks)
 
 ## Installation<a name="installation"></a>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@haensl/react-hooks",
-  "version": "1.10.0",
+  "version": "1.10.1",
   "description": "Assorted React hooks.",
   "main": "dist/hooks.cjs.js",
   "module": "dist/hooks.esm.js",


### PR DESCRIPTION
## 1.10.1
* [#71: Fix package badges.](https://github.com/haensl/hooks/issues/71)

Closes #71 